### PR TITLE
Code to move robot around the field with mouse

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -8,6 +8,7 @@ package frc.robot;
 
 import com.revrobotics.CANSparkMax.IdleMode;
 
+import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.geometry.Pose2d;
 import edu.wpi.first.wpilibj.geometry.Rotation2d;
@@ -47,6 +48,9 @@ public class Robot extends TimedRobot {
   public static double angleErrorAfterTurn = 0;
 
   private Pose2d initialPose2d = FieldMap.startPosition[1];
+
+  private AutoCommandInterface m_prevAutoCommand = null;
+
   /**
    * This function is run when the robot is first started up and should be used
    * for any initialization code.
@@ -136,6 +140,10 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void disabledInit() {
+    if (RobotBase.isSimulation()) {
+      m_robotContainer.robotDrive.setRobotFromFieldPose();
+    }
+
     if (Robot.isReal()) {
       m_robotContainer.climber.shoulder.setIdleMode(IdleMode.kCoast);
       m_robotContainer.climber.winch.setIdleMode(IdleMode.kCoast);
@@ -150,8 +158,9 @@ public class Robot extends TimedRobot {
     m_autoCommandInterface = chosenAuto.getSelected();
     //m_robotContainer.carouselCommand.schedule();
     // schedule the autonomous command (example)
-    if (m_autoCommandInterface != null) {
+    if (m_autoCommandInterface != null && m_autoCommandInterface != m_prevAutoCommand) {
       m_robotContainer.robotDrive.setPose(m_autoCommandInterface.getInitialPose());
+      m_prevAutoCommand = m_autoCommandInterface;
     }
   }
 
@@ -161,6 +170,10 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void autonomousInit() {
+    if (RobotBase.isSimulation()) {
+      m_robotContainer.robotDrive.setRobotFromFieldPose();
+    }
+
     m_robotContainer.carousel.resetEncoder();
     // Set motors to brake for the drive train
     m_robotContainer.robotDrive.setIdleMode(IdleMode.kBrake);
@@ -231,6 +244,9 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void testPeriodic() {
+    if (RobotBase.isSimulation()) {
+      m_robotContainer.robotDrive.moveAroundField();
+    }
   }
 
   @Override

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -8,6 +8,7 @@ package frc.robot;
 
 import com.revrobotics.CANSparkMax.IdleMode;
 
+import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -30,6 +31,10 @@ public class Robot extends TimedRobot {
   public static int RPMAdjustment;
   public static int HoodAdjustment;
   public static double angleErrorAfterTurn = 0;
+
+  private Pose2d initialPose2d = FieldMap.startPosition[1];
+
+  private AutoCommandInterface m_prevAutoCommand = null;
 
   /**
    * This function is run when the robot is first started up and should be used
@@ -112,6 +117,10 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void disabledInit() {
+    if (RobotBase.isSimulation()) {
+      m_robotContainer.robotDrive.setRobotFromFieldPose();
+    }
+
     if (Robot.isReal()) {
       m_robotContainer.climber.shoulder.setIdleMode(IdleMode.kCoast);
       m_robotContainer.climber.winch.setIdleMode(IdleMode.kCoast);
@@ -128,8 +137,9 @@ public class Robot extends TimedRobot {
     // Do not use the member variable m_autonomousCommand. Setting that signals
     //  that the command is running, which it is not, yet.
     AutoCommandInterface autoCommandInterface = chosenAuto.getSelected();
-    if (autoCommandInterface != null) {
-      m_robotContainer.robotDrive.setPose(autoCommandInterface.getInitialPose());
+    if (m_autoCommandInterface != null && m_autoCommandInterface != m_prevAutoCommand) {
+      m_robotContainer.robotDrive.setPose(m_autoCommandInterface.getInitialPose());
+      m_prevAutoCommand = m_autoCommandInterface;
     }
   }
 
@@ -139,6 +149,10 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void autonomousInit() {
+    if (RobotBase.isSimulation()) {
+      m_robotContainer.robotDrive.setRobotFromFieldPose();
+    }
+
     m_robotContainer.carousel.resetEncoder();
     // Set motors to brake for the drive train
     m_robotContainer.robotDrive.setIdleMode(IdleMode.kBrake);
@@ -213,6 +227,9 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void testPeriodic() {
+    if (RobotBase.isSimulation()) {
+      m_robotContainer.robotDrive.moveAroundField();
+    }
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/DriveTrain.java
+++ b/src/main/java/frc/robot/subsystems/DriveTrain.java
@@ -146,11 +146,6 @@ public class DriveTrain extends SubsystemBase {
     }
 
     public void setPose(Pose2d pose) {
-        // The left and right encoders MUST be reset when odometry is reset
-        leftEncoder.reset();
-        rightEncoder.reset();
-        odometry.resetPosition(pose, Rotation2d.fromDegrees(getGyroAngle()));
-
         if (RobotBase.isSimulation()) {
             // This is a bit hokey, but if the Robot jumps on the field, we need
             //   to reset the internal state of the DriveTrainSimulator.
@@ -158,8 +153,17 @@ public class DriveTrain extends SubsystemBase {
             //   NOTE: this assumes the robot is not moving, since we are not resetting
             //   the rate variables.
             drivetrainSimulator.setState(new Matrix<>(Nat.N7(), Nat.N1()));
+
+            // reset the GyroSim to match the driveTrainSim
+            // do it early so that "real" odometry matches this value
+            gyroAngleSim.set(-drivetrainSimulator.getHeading().getDegrees());
             fieldSim.setRobotPose(pose);
         }
+
+        // The left and right encoders MUST be reset when odometry is reset
+        leftEncoder.reset();
+        rightEncoder.reset();
+        odometry.resetPosition(pose, Rotation2d.fromDegrees(getGyroAngle()));
     }
       
     public void tankDriveVolts (double leftVolts, double rightVolts) {

--- a/src/main/java/frc/robot/subsystems/DriveTrain.java
+++ b/src/main/java/frc/robot/subsystems/DriveTrain.java
@@ -73,7 +73,6 @@ public class DriveTrain extends SubsystemBase {
     private EncoderSim rightEncoderSim;
     // The Field2d class simulates the field in the sim GUI. Note that we can have only one
     // instance!
-    // Does this belong somewhere else??
     private Field2d fieldSim;
     private SimDouble gyroAngleSim;
 
@@ -192,18 +191,10 @@ public class DriveTrain extends SubsystemBase {
         return Math.IEEEremainder(navX.getAngle(), 360) * -1; // -1 here for unknown reason look in documatation
     }
 
-    // private void resetHeading() {
-    //     navX.reset();
-    // }
-    
-    // private void resetEncoders() {
-    //     leftEncoder.reset();
-    //     rightEncoder.reset();
-    // }
-
     // This is the same as setPose() but leave here for compatibility
     public void resetOdometry (Pose2d pose) {
         setPose(pose);
+        // old code as in master branch. leave here until tested
         // resetEncoders();
         // //resetHeading();
         // odometry.resetPosition(pose, Rotation2d.fromDegrees(getGyroAngle()));
@@ -246,15 +237,12 @@ public class DriveTrain extends SubsystemBase {
         return new DifferentialDriveWheelSpeeds(leftEncoder.getRate(), rightEncoder.getRate());
     }
 
+    // This method will be called once per scheduler run
     @Override
     public void periodic() {
         odometry.update(Rotation2d.fromDegrees(getGyroAngle()), leftEncoder.getDistance(), rightEncoder.getDistance());
         SmartDashboard.putNumber("Heading", getHeading());
         SmartDashboard.putString("Pose", getPose().toString());
-        // SmartDashboard.putNumber("Vision Angle", SmartDashboard.getNumberArray("vision/target_info", new Double[]{0.0,0.0})[4] * 180.0 / 3.1416);
-        //SmartDashboard.putNumber("Arc tan adjustment", Math.atan(7.5 / SmartDashboard.getNumberArray("vision/target_info", new Double[]{0.0,0.0})[3]));
-
-        // This method will be called once per scheduler run
     }
 
     @Override


### PR DESCRIPTION
Update test mode to allow the user to move/rotate the robot with the mouse. Also include the functionality of
MoveAroundField command, since is it the same idea.

Note that DriveTrain.setPose() was changed to also reset the Gyro sim value, and this should be done before resetting the odometry. This fixes a bug in the move code: without it, the robot would change angles on mode changes in certain cases.